### PR TITLE
Fix NaN issue in the mean EVM computation

### DIFF
--- a/cognitive_engines/CE_FEC_Adaptation.cpp
+++ b/cognitive_engines/CE_FEC_Adaptation.cpp
@@ -7,89 +7,101 @@
 #define dprintf(...) /*__VA_ARGS__*/
 #endif
 
-
 // constructor
-CE_FEC_Adaptation::CE_FEC_Adaptation(){}
+CE_FEC_Adaptation::CE_FEC_Adaptation()
+: EVM_avg(0.0),
+  ind(0)
+{
+	memset(EVM_buff, 0, EVM_buff_len * sizeof(float));
+}
 
 // destructor
-CE_FEC_Adaptation::~CE_FEC_Adaptation() {}
+CE_FEC_Adaptation::~CE_FEC_Adaptation()
+{
+}
 
 // execute function
-void CE_FEC_Adaptation::execute(void * _args){
-    // type cast pointer to cognitive radio object
-    ExtensibleCognitiveRadio * ECR = (ExtensibleCognitiveRadio *) _args;
+void
+CE_FEC_Adaptation::execute(void * _args)
+{
+	// type cast pointer to cognitive radio object
+	ExtensibleCognitiveRadio * ECR = (ExtensibleCognitiveRadio *) _args;
 
-    // keep track of current and desired fec for rx and tx
-    int current_tx_fec = ECR->get_tx_fec0();
+	// keep track of current and desired fec for rx and tx
+	int current_tx_fec = ECR->get_tx_fec0();
 	int desired_tx_fec;
 	int desired_rx_fec = LIQUID_MODEM_QAM4;
 
 	// character array to write/read control information for the ECR
-    unsigned char control_info[6];
+	unsigned char control_info[6];
 
 	// only update average EVM  or tx fec for physical layer events
-    if(ECR->CE_metrics.CE_event == ExtensibleCognitiveRadio::PHY){
-        // define old and new EVM values
-        float EVM_old = EVM_buff[ind];
-        float EVM_new = ECR->CE_metrics.stats.evm;
-    
-		// update EVM history
-        EVM_buff[ind] = EVM_new;
+	if (ECR->CE_metrics.CE_event == ExtensibleCognitiveRadio::PHY) {
+		// define old and new EVM values
+		float EVM_old = EVM_buff[ind];
+		float EVM_new;
 
-        // update moving average EVM
-        EVM_avg += (EVM_new - EVM_old)/EVM_buff_len;
-
-        dprintf("\n---------------------------------------------------\n");
-		dprintf("New EVM: %f\n", EVM_new);
-        dprintf("Old EVM: %f\n", EVM_old);
-        dprintf("Average EVM: %f\n", EVM_avg);
-
-        // update rx fec scheme based on averaged EVM
-        if(EVM_avg > -15.0f){
-            dprintf("Setting desired rx fec to rate 1/2\n");
-            desired_rx_fec = LIQUID_FEC_CONV_V27;
-		}
-        else if(EVM_avg > -20.0f){
-            dprintf("Setting desired rx fec to rate 3/4\n");
-            desired_rx_fec = LIQUID_FEC_CONV_V27P34;
+		/*
+		 * Due to an invalid received frame, EVM may be a NaN.
+		 * If this is the case assign a proper value to indicate
+		 * a very bad EVM.
+		 */
+		if(isnanf(ECR->CE_metrics.stats.evm)){
+			EVM_new = 0;
 		}
 		else{
-            dprintf("Setting desired rx fec to rate 7/8\n");
-            desired_rx_fec = LIQUID_FEC_CONV_V27P78;
+			EVM_new = ECR->CE_metrics.stats.evm;
 		}
-        
+
+		// update EVM history
+		EVM_buff[ind] = EVM_new;
+
+		// update moving average EVM
+		EVM_avg += (EVM_new - EVM_old) / EVM_buff_len;
+
+		dprintf("\n---------------------------------------------------\n"); dprintf("New EVM: %f\n", EVM_new); dprintf("Old EVM: %f\n", EVM_old); dprintf("Average EVM: %f\n", EVM_avg);
+
+		// update rx fec scheme based on averaged EVM
+		if (EVM_avg > -15.0f) {
+			dprintf("Setting desired rx fec to rate 1/2\n");
+			desired_rx_fec = LIQUID_FEC_CONV_V27;
+		}
+		else if (EVM_avg > -20.0f) {
+			dprintf("Setting desired rx fec to rate 3/4\n");
+			desired_rx_fec = LIQUID_FEC_CONV_V27P34;
+		}
+		else {
+			dprintf("Setting desired rx fec to rate 7/8\n");
+			desired_rx_fec = LIQUID_FEC_CONV_V27P78;
+		}
+
 		// set control info to update the transmitter fec scheme
-        memcpy(control_info, &desired_rx_fec, sizeof(int));
+		memcpy(control_info, &desired_rx_fec, sizeof(int));
 		ECR->set_tx_control_info(control_info);
 
 		// increment the EVM buffer index and wrap around
-        ind++;
-        if(ind >= EVM_buff_len)
-            ind = 0;
-    
-	    // obtain the desired tx fec based on the received control information
+		ind++;
+		if (ind >= EVM_buff_len)
+			ind = 0;
+
+		// obtain the desired tx fec based on the received control information
 		ECR->get_rx_control_info(control_info);
-		desired_tx_fec = *(int*)control_info;
-		
+		desired_tx_fec = *(int*) control_info;
+
 		// update transmitter fec if necessary
-		if(ECR->CE_metrics.control_valid             && 
-		   current_tx_fec != desired_tx_fec          &&
-		   (desired_tx_fec == LIQUID_FEC_CONV_V27 ||
-		   desired_tx_fec == LIQUID_FEC_CONV_V27P34  ||
-		   desired_tx_fec == LIQUID_FEC_CONV_V27P78) 
-		  ){
-            dprintf("Setting tx FEC to: %i\n", desired_tx_fec);
+		if (ECR->CE_metrics.control_valid
+		        && current_tx_fec != desired_tx_fec
+		        && (desired_tx_fec == LIQUID_FEC_CONV_V27
+		                || desired_tx_fec == LIQUID_FEC_CONV_V27P34
+		                || desired_tx_fec == LIQUID_FEC_CONV_V27P78)) {
+			dprintf("Setting tx FEC to: %i\n", desired_tx_fec);
 			ECR->set_tx_fec0(desired_tx_fec);
-		}
-        dprintf("desired tx FEC: %i\n", desired_tx_fec);
-		dprintf("current tx FEC: %i\n", current_tx_fec);
-		dprintf("desired rx FEC: %i\n", desired_rx_fec);
-			
+		} dprintf("desired tx FEC: %i\n", desired_tx_fec); dprintf("current tx FEC: %i\n", current_tx_fec); dprintf("desired rx FEC: %i\n", desired_rx_fec);
+
 	}
-    else dprintf("CE was triggered by a timeout\n");
+	else
+		dprintf("CE was triggered by a timeout\n");
 }
 
 // custom function definitions
-
-
 

--- a/cognitive_engines/CE_Mod_Adaptation.cpp
+++ b/cognitive_engines/CE_Mod_Adaptation.cpp
@@ -7,87 +7,103 @@
 #define dprintf(...) /*__VA_ARGS__*/
 #endif
 
-
 // constructor
-CE_Mod_Adaptation::CE_Mod_Adaptation(){}
+CE_Mod_Adaptation::CE_Mod_Adaptation()
+: EVM_avg(0.0),
+  ind(0)
+{
+	memset(EVM_buff, 0, EVM_buffer_len * sizeof(float));
+}
 
 // destructor
-CE_Mod_Adaptation::~CE_Mod_Adaptation() {}
+CE_Mod_Adaptation::~CE_Mod_Adaptation()
+{
+}
 
 // execute function
-void CE_Mod_Adaptation::execute(void * _args){
-    // type cast pointer to cognitive radio object
-    ExtensibleCognitiveRadio * ECR = (ExtensibleCognitiveRadio *) _args;
-    
+void
+CE_Mod_Adaptation::execute(void * _args)
+{
+	// type cast pointer to cognitive radio object
+	ExtensibleCognitiveRadio * ECR = (ExtensibleCognitiveRadio *) _args;
 
-    // keep track of current and desired modulation for rx and tx
-    int current_tx_mod = ECR->get_tx_modulation();
+	// keep track of current and desired modulation for rx and tx
+	int current_tx_mod = ECR->get_tx_modulation();
 	int desired_tx_mod;
 	int desired_rx_mod = LIQUID_MODEM_QAM4;
 
 	// character array to write/read control information for the ECR
-    unsigned char control_info[6];
+	unsigned char control_info[6];
 
 	// only update average EVM  or tx modulation for physical layer events
-    if(ECR->CE_metrics.CE_event == ExtensibleCognitiveRadio::PHY){
-        
+	if (ECR->CE_metrics.CE_event == ExtensibleCognitiveRadio::PHY) {
+
 		// define old and new EVM values
-        float EVM_old = EVM_buff[ind];
-        float EVM_new = ECR->CE_metrics.stats.evm;
-    
+		float EVM_old = EVM_buff[ind];
+		float EVM_new;
+
+		/*
+		 * Due to an invalid received frame, EVM may be a NaN.
+		 * If this is the case assign a proper value to indicate
+		 * a very bad EVM.
+		 */
+		if(isnanf(ECR->CE_metrics.stats.evm)){
+			EVM_new = 0;
+		}
+		else{
+			EVM_new = ECR->CE_metrics.stats.evm;
+		}
+
 		// update EVM history
-        EVM_buff[ind] = EVM_new;
+		EVM_buff[ind] = EVM_new;
 
-        // update moving average EVM
-        EVM_avg += (EVM_new - EVM_old)/EVM_buffer_len;
+		// update moving average EVM
+		EVM_avg += (EVM_new - EVM_old) / EVM_buffer_len;
 
-        dprintf("\n------------------------------------------------\n");
-		dprintf("\nNew EVM: %f\n", EVM_new);
-        dprintf("Old EVM: %f\n", EVM_old);
-        dprintf("Average EVM: %f\n", EVM_avg);
+		dprintf("\n------------------------------------------------\n");
+		dprintf("\nNew EVM: %f\n", EVM_new); dprintf("Old EVM: %f\n", EVM_old);
+		dprintf("Average EVM: %f\n", EVM_avg);
 
-        // update desired receive modulation scheme based on averaged EVM
-        if(EVM_avg > -15.0f){
-            dprintf("Setting desired rx modulation to QPSK\n");
-            desired_rx_mod = LIQUID_MODEM_QAM4;
+		// update desired receive modulation scheme based on averaged EVM
+		if (EVM_avg > -15.0f) {
+			dprintf("Setting desired rx modulation to QPSK\n");
+			desired_rx_mod = LIQUID_MODEM_QAM4;
 		}
-        else if(EVM_avg > -25.0f){
-            dprintf("Setting desired rx modulation to 16-QAM\n");
-            desired_rx_mod = LIQUID_MODEM_QAM16;
+		else if (EVM_avg > -25.0f) {
+			dprintf("Setting desired rx modulation to 16-QAM\n");
+			desired_rx_mod = LIQUID_MODEM_QAM16;
 		}
-        else if(EVM_avg > -35.0f){
-            dprintf("Setting desired rx modulation to 64-QAM\n");
-            desired_rx_mod = LIQUID_MODEM_QAM64;
+		else if (EVM_avg > -35.0f) {
+			dprintf("Setting desired rx modulation to 64-QAM\n");
+			desired_rx_mod = LIQUID_MODEM_QAM64;
 		}
 
-        // set control info to update the transmitter modulation scheme
-        memcpy(control_info, &desired_rx_mod, sizeof(int));
+		// set control info to update the transmitter modulation scheme
+		memcpy(control_info, &desired_rx_mod, sizeof(int));
 		ECR->set_tx_control_info(control_info);
 
 		// increment the EVM buffer index and wrap around
-        ind++;
-        if(ind >= EVM_buffer_len)
-            ind = 0;
-    
-	    // obtain the desired tx modulation based on the received control information
+		ind++;
+		if (ind >= EVM_buffer_len)
+			ind = 0;
+
+		// obtain the desired tx modulation based on the received control information
 		ECR->get_rx_control_info(control_info);
-		desired_tx_mod = *(int *)control_info;
-		
+		desired_tx_mod = *(int *) control_info;
+
 		// update transmitter modulation if necessary
-		if(ECR->CE_metrics.control_valid       && 
-		   current_tx_mod != desired_tx_mod    &&
-		   desired_tx_mod >= LIQUID_MODEM_QAM4 &&
-		   desired_tx_mod <= LIQUID_MODEM_QAM64
-		  ){
-            dprintf("Setting tx modulation\n");
+		if (ECR->CE_metrics.control_valid
+		        && current_tx_mod != desired_tx_mod
+		        && desired_tx_mod >= LIQUID_MODEM_QAM4
+		        && desired_tx_mod <= LIQUID_MODEM_QAM64) {
+			dprintf("Setting tx modulation\n");
 			ECR->set_tx_modulation(desired_tx_mod);
 		}
-	
+
 	}
-    else dprintf("CE was triggered by a timeout\n");
+	else
+		dprintf("CE was triggered by a timeout\n");
 }
 
 // custom function definitions
-
-
 

--- a/logs/octave/Plot_CR_PHY_RX.m
+++ b/logs/octave/Plot_CR_PHY_RX.m
@@ -59,7 +59,7 @@ plot(phy_rx_t,phy_rx_fec0);
 title('Inner Forward Error Correction');
 xlabel('Time (s)');
 ylabel('FEC Scheme');
-labels = {'Unknown','None','Repeat (1/3)','Repeat(1/5)','Hamming (7/4)','Hamming (8/4)','Hamming (12/8)','Golay (24/12)','SEC-DED (22/16)','SEC-DED (22/16)','SEC-DED (39/32)','SEC-DED72/64)','Convultional (1/2,7)','Convolutional (1/2,9)','Convolutional (1/3,9)','Convolutional (1/6,15)','Convolutional (2/3,7)','Convolutional (3/4,7)','Convolutional (4/5,7)','Convolutional (5/6,7)','Convolutional(6/7,7)','Convolutional (7/8,7)','Convolutional (2/3,9)','Convolutional (3/4,9)','Convolutional (4/5,9)','Convolutional (5/6,9)','Convolutional(6/7,9)','Convolutional(7/8,9)','Reed-Solomon (8)'};
+labels = {'Unknown','None','Repeat (1/3)','Repeat(1/5)','Hamming (7/4)','Hamming (8/4)','Hamming (12/8)','Golay (24/12)','SEC-DED (22/16)','SEC-DED (39/32)','SEC-DED72/64)','Convultional (1/2,7)','Convolutional (1/2,9)','Convolutional (1/3,9)','Convolutional (1/6,15)','Convolutional (2/3,7)','Convolutional (3/4,7)','Convolutional (4/5,7)','Convolutional (5/6,7)','Convolutional(6/7,7)','Convolutional (7/8,7)','Convolutional (2/3,9)','Convolutional (3/4,9)','Convolutional (4/5,9)','Convolutional (5/6,9)','Convolutional(6/7,9)','Convolutional(7/8,9)','Reed-Solomon (8)'};
 set(gca, 'YTick', 0:28, 'YTickLabel', labels);
 
 figure;
@@ -67,7 +67,7 @@ plot(phy_rx_t,phy_rx_fec1);
 title('Outter Forward Error Correction');
 xlabel('Time (s)');
 ylabel('FEC Scheme');
-labels = {'Unknown','None','Repeat (1/3)','Repeat(1/5)','Hamming (7/4)','Hamming (8/4)','Hamming (12/8)','Golay (24/12)','SEC-DED (22/16)','SEC-DED (22/16)','SEC-DED (39/32)','SEC-DED72/64)','Convultional (1/2,7)','Convolutional (1/2,9)','Convolutional (1/3,9)','Convolutional (1/6,15)','Convolutional (2/3,7)','Convolutional (3/4,7)','Convolutional (4/5,7)','Convolutional (5/6,7)','Convolutional(6/7,7)','Convolutional (7/8,7)','Convolutional (2/3,9)','Convolutional (3/4,9)','Convolutional (4/5,9)','Convolutional (5/6,9)','Convolutional(6/7,9)','Convolutional(7/8,9)','Reed-Solomon (8)'};
+labels = {'Unknown','None','Repeat (1/3)','Repeat(1/5)','Hamming (7/4)','Hamming (8/4)','Hamming (12/8)','Golay (24/12)','SEC-DED (22/16)','SEC-DED (39/32)','SEC-DED72/64)','Convultional (1/2,7)','Convolutional (1/2,9)','Convolutional (1/3,9)','Convolutional (1/6,15)','Convolutional (2/3,7)','Convolutional (3/4,7)','Convolutional (4/5,7)','Convolutional (5/6,7)','Convolutional(6/7,7)','Convolutional (7/8,7)','Convolutional (2/3,9)','Convolutional (3/4,9)','Convolutional (4/5,9)','Convolutional (5/6,9)','Convolutional(6/7,9)','Convolutional(7/8,9)','Reed-Solomon (8)'};
 set(gca, 'YTick', 0:28, 'YTickLabel', labels);
 	
 	


### PR DESCRIPTION
NaN can occur in two different scenarios:
1. Wrongly initialized EVM buffer
2. NaN during a reception of a corrupted frame

If a NaN value is passed into the EVM buffer all
the consecutive calculations produce NaN result.
This problem, forces the Mod_Adpation and FEC_Adpatation CE
to use always the default mod/fec.
