### PR TITLE
minor cleanup/bug fix in set/get_tx_control_info

### DIFF
--- a/src/ECR.cpp
+++ b/src/ECR.cpp
@@ -565,15 +565,13 @@ unsigned int ExtensibleCognitiveRadio::get_tx_taper_len() {
 // set control info (must have length 6)
 void ExtensibleCognitiveRadio::set_tx_control_info(
     unsigned char *_control_info) {
-  for (int i = 0; i < 6; i++)
-    tx_header[i + 2] = _control_info[i];
-  memcpy(_control_info, &tx_header[2], 6 * sizeof(unsigned char));
+  memcpy(&tx_header[2], _control_info, 6 * sizeof(unsigned char));
 }
 
 // get control info
 void ExtensibleCognitiveRadio::get_tx_control_info(
     unsigned char *_control_info) {
-  memcpy(&tx_header[2], _control_info, 6 * sizeof(unsigned char));
+  memcpy(_control_info, &tx_header[2], 6 * sizeof(unsigned char));
 }
 
 // set tx payload length


### PR DESCRIPTION
set_tx_control_info() previously copied the contents of _control_info into tx_header with a for loop, and then copied the last 6 bytes of tx_header back into the _control_info array with memset. This doesn't break anything, but it probably wasn't intentional.

get_tx_control_info() copied the contents of _control_info into tx_header, rather than the other way around.  This doesn't work, but this function may be unneeded anyway, since the tx_control_info is always user set.  
