### PR TITLE
New Primary Engine based on Markov chain

### DIFF
--- a/cognitive_engines/primary_user_engines/CE_PU_MARKOV_Chain_Tx/CE_PU_MARKOV_Chain_Tx.cpp
+++ b/cognitive_engines/primary_user_engines/CE_PU_MARKOV_Chain_Tx/CE_PU_MARKOV_Chain_Tx.cpp
@@ -97,33 +97,33 @@ void CE_PU_MARKOV_Chain_Tx::RANDOM_OUTOCME(ExtensibleCognitiveRadio *ECR) {
 void CE_PU_MARKOV_Chain_Tx::PU_TX_Behaviour(ExtensibleCognitiveRadio *ECR) {
   tx_freq = ECR->get_tx_freq();
 
-                    //checking for first state CHANNEL_1
-                    if (tx_freq == CHANNEL_1){
-                    if (state_probability == 0)
-                      ECR->set_tx_freq(CHANNEL_1);
-                    else if(state_probability>=1 || state_probability<4)
-                      ECR->set_tx_freq(CHANNEL_2);
-                    else 
-                      ECR->set_tx_freq(CHANNEL_3);
-                  }
-                    //checking for second state CHANNEL_2
-                  else if (tx_freq == CHANNEL_2){
-                    if (state_probability == 0 )    
-                      ECR->set_tx_freq(CHANNEL_1);
-                    else if(state_probability>=1 || state_probability<6)
-                      ECR->set_tx_freq(CHANNEL_2);
-                    else 
-                      ECR->set_tx_freq(CHANNEL_3);
-                  }
-                    //checking for Third state CHANNEL_3
-                  else
-                  {
-                    if (state_probability == 0)
-                      ECR->set_tx_freq(CHANNEL_1);
-                    else if(state_probability>=1 || state_probability<4)
-                      ECR->set_tx_freq(CHANNEL_2);
-                    else 
-                      ECR->set_tx_freq(CHANNEL_3);
-                  }
+//checking for second state CHANNEL_1
+if (tx_freq == CHANNEL_1){
+    if (state_probability == 0)
+        ECR->set_tx_freq(CHANNEL_1);
+    else if(state_probability>=1 || state_probability<4)
+        ECR->set_tx_freq(CHANNEL_2);
+    else 
+        ECR->set_tx_freq(CHANNEL_3);
+    }
+
+//checking for second state CHANNEL_2
+else if (tx_freq == CHANNEL_2){
+    if (state_probability == 0 )    
+        ECR->set_tx_freq(CHANNEL_1);
+    else if(state_probability>=1 || state_probability<6)
+        ECR->set_tx_freq(CHANNEL_2);
+    else 
+        ECR->set_tx_freq(CHANNEL_3);
+    }
+//checking for Third state CHANNEL_3
+else{
+    if (state_probability == 0)
+        ECR->set_tx_freq(CHANNEL_1);
+    else if(state_probability>=1 || state_probability<4)
+        ECR->set_tx_freq(CHANNEL_2);
+    else 
+        ECR->set_tx_freq(CHANNEL_3);
+    }
 }
 

--- a/cognitive_engines/primary_user_engines/CE_PU_MARKOV_Chain_Tx/CE_PU_MARKOV_Chain_Tx.cpp
+++ b/cognitive_engines/primary_user_engines/CE_PU_MARKOV_Chain_Tx/CE_PU_MARKOV_Chain_Tx.cpp
@@ -1,0 +1,129 @@
+/*
+ * Author: astro
+ * Purpose: Design an engine for primary user (member of the cognitive radio network)
+            which is based on markov chain model
+ * Language:  C/C++
+ * Dependencies: CRTS, UHD DRIVERS, LIQUID DSP
+ *               This version is stable only for USRP 1 AND USRP 2 
+                  AND it doesnt work on USRPX SERIES.
+ * Development:  CORNET TESTBED
+ * Program subroutine:
+
+//no need to design the transition matrix, just demo.
+/*with 3 STATES theres is 8 possible transitions
+
+                +-------------------------++--------++--------++---------+
+                |        MARKOV Chain Probability                        |
+                |           states transition                            |
+                +-------------------------++--------++--------++---------+
+                | CHANNEL 1.   |   CHANNEL 2       |  CHANNEL 3          |
+----------------+--------------------------------------------------------+
+|  CHANNEL 1  |  P(CH_1|CH_1)= 0.1| P(CH_1|CH_2)=0.3  | P(CH_1|CH_3)=0.6 |
++-------------+-------+--------+--------++--------++--------++-----------+
+|  CHANNEL 2  |  P(CH_2|CH_1)= 0.1| P(CH_2|CH_2)=0.5  | P(CH_2|CH_3)=0.4 |
++-------------+-------+--------+--------++--------++--------++--------+--+
+|  CHANNEL 3  |  P(CH_3|CH_1)= 0.1| P(CH_3|CH_2)=0.2  | P(CH_3|CH_3)=0.7 |
++-------------+-------+--------+--------++--------++--------++-----------+
+
+
+*/
+
+
+#include "CE_PU_MARKOV_Chain_Tx.hpp"
+
+// constructor
+CE_PU_MARKOV_Chain_Tx::CE_PU_MARKOV_Chain_Tx(int argc, char **argv, ExtensibleCognitiveRadio *_ECR) {
+  ECR = _ECR;
+  first_execution = 1;
+  period_s = 5;
+  rx_flag=1;
+}
+
+CE_PU_MARKOV_Chain_Tx::~CE_PU_MARKOV_Chain_Tx() {}
+
+
+// execute function
+void CE_PU_MARKOV_Chain_Tx::execute() {
+  
+  if (rx_flag){
+    ECR->stop_rx();
+    rx_flag = 0;
+  } 
+
+  gettimeofday(&tv, NULL);
+
+  if (first_execution) {
+    switch_time_s = tv.tv_sec + period_s;
+    ECR->set_ce_timeout_ms(100.0);
+    first_execution = 0;
+  }
+
+  if (tv.tv_sec >= switch_time_s) {
+    // update switch time
+    switch_time_s += period_s;
+
+    hopping++;
+    printf("+--------------------------------------------------------------------------------\n \t \t HOPPING \t \t # %d \n+--------------------------------------------------------------------------------\n",hopping);
+
+    if (ECR->get_tx_freq() == CHANNEL_1) printf("Current State: CHANNEL 1 ::::: ");
+    else if (ECR->get_tx_freq()== CHANNEL_2) printf("Current State: CHANNEL 2 ::::: ");
+    else printf("Current State: CHANNEL 3 ::::: ");
+   // printf("process ................. \n");
+    RANDOM_OUTOCME(ECR);
+    PU_TX_Behaviour(ECR);
+    PU_RX_Behaviour(ECR);
+
+    if (ECR->get_tx_freq() == CHANNEL_1) printf("Next State: CHANNEL 1\n");
+    else if (ECR->get_tx_freq()== CHANNEL_2) printf("Next State: CHANNEL 2\n");
+    else printf("Next State: CHANNEL 3\n");
+
+/*
+    printf("Transmit frequency: %f\n", ECR->get_tx_freq());
+    printf("Receiver frequency: %f\n\n", ECR->get_rx_freq());
+*/
+
+  }
+}
+
+void CE_PU_MARKOV_Chain_Tx::RANDOM_OUTOCME(ExtensibleCognitiveRadio *ECR) {
+    static constexpr float Sample_Space[10]={0,1,2,3,4,5,6,7,8,9};
+    outcome= rand() % 10;
+    state_probability = Sample_Space[outcome]; //Sample_Space[0],...Sample_Space[9]
+}
+
+
+
+
+void CE_PU_MARKOV_Chain_Tx::PU_TX_Behaviour(ExtensibleCognitiveRadio *ECR) {
+  tx_freq = ECR->get_tx_freq();
+
+                    //checking for first state CHANNEL_1
+                    if (tx_freq == CHANNEL_1){
+                    if (state_probability == 0)
+                      ECR->set_tx_freq(CHANNEL_1);
+                    else if(state_probability>=1 || state_probability<4)
+                      ECR->set_tx_freq(CHANNEL_2);
+                    else 
+                      ECR->set_tx_freq(CHANNEL_3);
+                  }
+                    //checking for second state CHANNEL_2
+                  else if (tx_freq == CHANNEL_2){
+                    if (state_probability == 0 )    
+                      ECR->set_tx_freq(CHANNEL_1);
+                    else if(state_probability>=1 || state_probability<6)
+                      ECR->set_tx_freq(CHANNEL_2);
+                    else 
+                      ECR->set_tx_freq(CHANNEL_3);
+                  }
+                    //checking for Third state CHANNEL_3
+                  else
+                  {
+                    if (state_probability == 0)
+                      ECR->set_tx_freq(CHANNEL_1);
+                    else if(state_probability>=1 || state_probability<4)
+                      ECR->set_tx_freq(CHANNEL_2);
+                    else 
+                      ECR->set_tx_freq(CHANNEL_3);
+                  }
+}
+

--- a/cognitive_engines/primary_user_engines/CE_PU_MARKOV_Chain_Tx/CE_PU_MARKOV_Chain_Tx.cpp
+++ b/cognitive_engines/primary_user_engines/CE_PU_MARKOV_Chain_Tx/CE_PU_MARKOV_Chain_Tx.cpp
@@ -9,8 +9,8 @@
  * Development:  CORNET TESTBED
  * Program subroutine:
 
-//no need to design the transition matrix, just demo.
-/*with 3 STATES theres is 8 possible transitions
+no need to design the transition matrix, just demo.
+with 3 STATES theres is 8 possible transitions
 
                 +-------------------------++--------++--------++---------+
                 |        MARKOV Chain Probability                        |
@@ -71,7 +71,7 @@ void CE_PU_MARKOV_Chain_Tx::execute() {
    // printf("process ................. \n");
     RANDOM_OUTOCME(ECR);
     PU_TX_Behaviour(ECR);
-    PU_RX_Behaviour(ECR);
+    //PU_RX_Behaviour(ECR);
 
     if (ECR->get_tx_freq() == CHANNEL_1) printf("Next State: CHANNEL 1\n");
     else if (ECR->get_tx_freq()== CHANNEL_2) printf("Next State: CHANNEL 2\n");

--- a/cognitive_engines/primary_user_engines/CE_PU_MARKOV_Chain_Tx/CE_PU_MARKOV_Chain_Tx.hpp
+++ b/cognitive_engines/primary_user_engines/CE_PU_MARKOV_Chain_Tx/CE_PU_MARKOV_Chain_Tx.hpp
@@ -1,0 +1,52 @@
+#ifndef _CE_PU_MARKOV_CHAIN_TX_
+#define _CE_PU_MARKOV_CHAIN_TX_
+
+#include <stdio.h>
+#include <sys/time.h>
+#include "extensible_cognitive_radio.hpp"
+#include "cognitive_engine.hpp"
+#include "timer.h"
+
+//#define STATES 3
+#define CH_1 833e6
+#define CH_2 836e6
+#define CH_3 838e6
+
+
+
+class CE_PU_MARKOV_Chain_Tx : public CognitiveEngine {
+public:
+  CE_PU_MARKOV_Chain_Tx(int argc, char**argv, ExtensibleCognitiveRadio *_ECR);
+  ~CE_PU_MARKOV_Chain_Tx();
+  virtual void execute();
+
+private:
+
+//STATE_SPACE={CHANNEL_1, CHANNEL_2, CHANNEL_3}
+static constexpr float CHANNEL_1 =CH_1;
+static constexpr float CHANNEL_2 =CH_2;
+static constexpr float CHANNEL_3 =CH_3;
+
+float tx_freq,rx_freq;
+float state_probability;
+short outcome;
+short rx_flag;
+int hopping =0;
+
+//OS time related parameters for synch
+struct timeval tv;
+time_t switch_time_s;
+int period_s;
+int first_execution;
+
+//memeber fuctions
+void RANDOM_OUTOCME(ExtensibleCognitiveRadio *ECR); //produce random variable R.V.
+void PU_TX_Behaviour(ExtensibleCognitiveRadio *ECR);//change the TX states based on R.V.
+//void PU_RX_Behaviour(ExtensibleCognitiveRadio *ECR);//change the RX states based on R.V.
+
+
+
+};
+
+#endif
+ 


### PR DESCRIPTION
This is simple Cognitive engine implementation for PU to switch it's operating frequency based on MARKOV chains, where the PU change the Center Frequency according to the the given probability[1].
[1]

|               | CHANNEL 1           | CHANNEL 2          | CHANNEL 3        |
|---------------|:-------------------:|:------------------:|:----------------:|
|CHANNEL 1      | P(CH_1/CH_1)= 0.1   | P(CH_1/CH_2)=0.3   | P(CH_1/CH_3)=0.6 |
|CHANNEL 1      | P(CH_2/CH_1)= 0.1   | P(CH_2/CH_2)=0.5   | P(CH_2/CH_3)=0.4 |
|CHANNEL 1      | P(CH_3/CH_1)= 0.1   | P(CH_3/CH_2)=0.2   | P(CH_3/CH_3)=0.7 |             
  


The implementation uses 2 member function:
```
1. RANDOM_OUTOCME(ECR);   //for generating the random variable from a uniform distribution
2. PU_TX_Behaviour(ECR);        //for selecting the channel according the given probabilities 
```
CE-Document and sample output:
[Primary user Engine.pdf](https://github.com/ericps1/crts/files/1082167/Primary.user.Engine.pdf)
makefile:

[makefile.txt](https://github.com/ericps1/crts/files/1082169/makefile.txt)


